### PR TITLE
持ち曲一覧機能の追加

### DIFF
--- a/src/components/PaginationNav.tsx
+++ b/src/components/PaginationNav.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { Button, Flex } from '@chakra-ui/react'
+
+interface Props {
+  pagesQuantity: number
+  currentPage: number
+  handlePageChange: any
+}
+
+const SenpaiUsersTable: React.FC<Props> = ({
+  pagesQuantity,
+  currentPage,
+  handlePageChange
+}) => {
+  return (
+    <Flex justify="end" align="center">
+      <Button
+        onClick={() => handlePageChange(-1)}
+        isDisabled={currentPage === 0}
+      >
+        前
+      </Button>
+      {currentPage + 1} / {pagesQuantity}
+      <Button
+        onClick={() => handlePageChange(1)}
+        isDisabled={currentPage === pagesQuantity - 1}
+      >
+        次
+      </Button>
+    </Flex>
+  )
+}
+
+export default SenpaiUsersTable

--- a/src/components/Tables/SongsTable.tsx
+++ b/src/components/Tables/SongsTable.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import { Text, Table, Thead, Tbody, Tr, Th, Td } from '@chakra-ui/react'
+import { usePagination } from 'hooks/usePagination'
+import PaginationNav from 'components/PaginationNav'
+import { Song } from 'models'
+
+interface Props {
+  songs: Song[]
+}
+
+const SongsTable: React.FC<Props> = ({ songs }) => {
+  const itemsPerPage = 30
+  const { currentPage, slicedItems, pagesQuantity, handlePageChange } =
+    usePagination(itemsPerPage, songs)
+
+  return (
+    <>
+      <Table variant="simple" border="2px" borderColor="gray.200">
+        <Thead backgroundColor="gray.200">
+          <Tr>
+            <Th px={6} py={4}>曲名</Th>
+            <Th p={4}>アーティスト</Th>
+            <Th p={4}>キー</Th>
+          </Tr>
+        </Thead>
+        <Tbody backgroundColor="white">
+          {slicedItems.map((song: Song) => (
+            <Tr key={song.songId}>
+              <Td w="50%">
+                <Text>{song.title}</Text>
+              </Td>
+              <Td w="40%">
+                <Text>{song.artist}</Text>
+              </Td>
+              <Td w="10%">
+                <Text>{song.key}</Text>
+              </Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+      <PaginationNav
+        pagesQuantity={pagesQuantity}
+        currentPage={currentPage}
+        handlePageChange={handlePageChange}
+      />
+    </>
+  )
+}
+
+export default SongsTable

--- a/src/db/SongRepository.ts
+++ b/src/db/SongRepository.ts
@@ -1,18 +1,25 @@
 import type {
   Uid,
-  CreateSongDto
+  CreateSongDto,
+  Song
 } from 'models/index'
-import { collection, addDoc } from 'firebase/firestore'
+import { collection, getDocs, addDoc } from 'firebase/firestore'
 import { db } from 'lib/firebase'
 
+const usersCollection = 'users'
+const songsCollection = 'songs'
+
 export default class SongRepository {
-  // async findById(userId: Uid): Promise<User> {
-  //   const userSnapshot = await db.collection('users').doc(userId).get()
-  //   return userSnapshot
-  // }
+  async findAll(userId: Uid): Promise<Song[]> {
+    const songsSnapshot = await getDocs(collection(db, usersCollection, userId, songsCollection))
+    const songs = songsSnapshot.docs.map((doc) => {
+      return doc.data() as Song
+    })
+    return songs
+  }
 
   async create(userId: Uid, dto: CreateSongDto) {
-    await addDoc(collection(db, 'users', userId, 'songs'), dto)
+    await addDoc(collection(db, usersCollection, userId, songsCollection), dto)
   }
 
   // async update(

--- a/src/hooks/usePagination.ts
+++ b/src/hooks/usePagination.ts
@@ -1,0 +1,40 @@
+import { useState, useMemo, useCallback } from 'react'
+
+type UsePaginationReturnType = {
+  currentPage: number
+  slicedItems: any
+  pagesQuantity: number
+  handlePageChange: (toPage: number) => void
+}
+
+export const usePagination = <ItemType>(
+  itemsPerPage: number,
+  items: ItemType[]
+): UsePaginationReturnType => {
+  const [currentPage, setCurrentPage] = useState(0)
+  const cursorHead = useMemo(() => currentPage * itemsPerPage, [currentPage])
+  const cursorTail = useMemo(
+    () => (currentPage + 1) * itemsPerPage,
+    [currentPage]
+  )
+
+  const pagesQuantity = useMemo(() => {
+    return Math.ceil(items.length / itemsPerPage)
+  }, [items.length])
+
+  const handlePageChange = useCallback((toPage: number) => {
+    setCurrentPage(currentPage + toPage)
+  }, [])
+
+  const slicedItems = useMemo(
+    () => items.slice(cursorHead, cursorTail),
+    [cursorHead, cursorTail]
+  )
+
+  return {
+    currentPage,
+    slicedItems,
+    pagesQuantity,
+    handlePageChange
+  }
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,15 +1,40 @@
 import Link from 'next/link'
-import Layout from '../components/Layout'
+import { useRecoilValue } from 'recoil'
+import Layout from 'components/Layout'
+import SongsTable from 'components/Tables/SongsTable'
+import { Button } from '@chakra-ui/button'
+import { userState } from 'atoms'
+import { useMemo } from 'react'
+import SongRepository from 'db/SongRepository'
 
-const IndexPage = () => (
-  <Layout title="Home | Next.js + TypeScript Example">
-    <h1>Hello Next.js 👋</h1>
-    <p>
-      <Link href="/about">
-        <a>About</a>
-      </Link>
-    </p>
-  </Layout>
-)
+const IndexPage = ({ songsServer }) => {
+  const user = useRecoilValue(userState)
+
+  return (
+    <Layout>
+      <p>
+        <Link href="/register">
+          <a>Register</a>
+        </Link>
+      </p>
+      <p>user: { user ? user.username : 'no login'}</p>
+      {/* 持ち曲一覧 */}
+      {/* <p>{songsServer.length}</p> */}
+      <SongsTable songs={songsServer} />
+    </Layout>
+  )
+}
 
 export default IndexPage
+
+export async function getStaticProps() {
+  const songRepository = new SongRepository()
+  const userId = 'x8T7SlQ1AReWaR0zyFoyadlhAdd2'
+  const songs = await songRepository.findAll(userId)
+  const songsServer = JSON.parse(JSON.stringify(songs))
+  return {
+    props: {
+      songsServer
+    }
+  }
+}


### PR DESCRIPTION
## 概要

持ち曲一覧機能の追加

## 変更内容

- 持ち曲一覧のテーブル
  - getStaticPropsでfirestoreから持ち曲一覧を取得
- ページネーション用のhooksを追加